### PR TITLE
Added Tailwind config to include /src/ dir

### DIFF
--- a/front_end_project/tailwind.config.js
+++ b/front_end_project/tailwind.config.js
@@ -1,12 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./constants/**/*.{js,ts,jsx,tsx,mdx}",
-    "./layouts/**/*.{js,ts,jsx,tsx,mdx}",
-    ".",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
     fontFamily: {


### PR DESCRIPTION
Apologies, I had forgotten to include /src/ for Tailwind CSS to read from #100. This has now been fixed and has been tested to include the class names on all the dir.