### PR TITLE
- Mailing list template

### DIFF
--- a/back_end_project/proxy-api/routes/mailgun/mailgun.js
+++ b/back_end_project/proxy-api/routes/mailgun/mailgun.js
@@ -48,14 +48,14 @@ router.post(subRouteDefinitions.subscribe, async (req, res) => {
   
       // Upon successful subscription, return the response
       res.status(200).json({
-        message: 'Successfully subscribed address to list',
+        message: 'Successfully subscribed address to Chameleon Mailing list',
       });
     } 
     
     catch (error) {
       // Return the error with status 400
       res.status(400).json({
-        message: error || 'Failed to subscribe address to list',
+        message: error || 'Failed to subscribe address to Chameleon Mailing list',
       });
     }
 
@@ -76,14 +76,14 @@ router.post(subRouteDefinitions.unsubscribe, async (req, res) => {
 
         // Upon successful update, return the response
         res.status(200).json({
-            message: 'Successfully unsubscribed address from list',
+            message: 'Successfully unsubscribed address from Chameleon Mailing list',
         });
     } 
     
     // If an error occurs, respond with it
     catch (error) {
         res.status(400).json({
-            message: error || 'Failed to unsubscribe address from list',
+            message: error || 'Failed to unsubscribe address from Chameleon Mailing list',
         });
     }
 
@@ -98,14 +98,14 @@ router.post(subRouteDefinitions.removeAddress, async (req, res) => {
         // Despite the call name, the member will not be physically harmed (according to the documentation)
         await mg.lists.members.destroyMember(mailing_list_domain, req.body.address);
         res.status(200).json({
-            message: 'Successfully deleted address from list',
+            message: 'Successfully deleted address Chameleon Mailing from list',
         });
     }
 
     // If an error occurs, respond with it
     catch (error) {
         res.status(400).json({
-            message: error || 'Failed to delete address from list',
+            message: error || 'Failed to delete address Chameleon Mailing from list',
         });
     }
 

--- a/back_end_project/proxy-api/routes/mailgun/sendMessage.js
+++ b/back_end_project/proxy-api/routes/mailgun/sendMessage.js
@@ -1,0 +1,43 @@
+/* This file should be used to send messages to the mailing list. 
+This form should never link to any user facing UI / UX elements 
+and is for developer use only. This file can and will likely 
+need to be customised to suit the evolving needs of the content 
+sent in Chameleon newsletter emails. Please refer to Mailgun API
+sending documentation for more details: 
+https://documentation.mailgun.com/en/latest/api-sending.html#sending */
+
+/* .env file used in local implementation and will need to be recreated 
+if running on localhost, API keys / domain intended to be hosted on GCP
+for security purposes. API key and domain can be found within Chameleon Mailgun account. 
+lines 14 - 16 will need to be updated to reflect this once transfer from AWS is complete */
+
+const API_KEY = process.env.MAILGUN_API_KEY;
+const DOMAIN = process.env.MAILGUN_DOMAIN;
+const toList = process.env.MAILGUN_MAILING_LIST;
+
+import formData from 'form-data'; // Form data module allowing submit functionality. 
+import Mailgun from 'mailgun.js'; // Import Mailgun API wrapper, allowing interaction with Mailgun. 
+
+// Send new email function. 
+// To send your new email after compoisition, run the following command from the root of this folder: node sendMessage  
+const mailgun = new Mailgun(formData);
+const client = mailgun.client({ username: 'api', key: API_KEY });
+
+(async () => {
+    try {
+
+        const data = {
+            from: 'Chameleon Newsletter <me@samples.mailgun.org>', // From address, can be customised as needed
+            to: [toList], // Email address managing mailing list, sends to all subscribed users.
+            subject: 'TEST', // Subject line. 
+            text: 'Chameleon new newsletter test!', // Plain text.
+            html: '<html>Insert HTML elements here</html>', // HTML section, allowing for greater customisation of emails.
+        };
+
+        // Await results of send, if failed, print message to user. 
+        const result = await client.messages.create(DOMAIN, data);
+        console.log(result);
+    } catch (error) {
+        console.error('Email failed to send, please try again shortly', error);
+    }
+})();


### PR DESCRIPTION
- Created template for sending emails to Chameleon mailing list.

- Updated error messages in Proxy API to include reference to Chameleon brand name.

- Will require GCP to be configured before backend services can go live.

Screenshot of template attached. 
![Screenshot 2023-11-29 at 3 15 16 pm](https://github.com/Chameleon-company/Chameleon-Website/assets/87591425/d57a89c8-7c48-4e38-9db1-1f202707d854)
