### PR TITLE
CI/CD - GitHub action to build and push Docker image

### DIFF
--- a/front_end_project/.github/workflow/build.yaml
+++ b/front_end_project/.github/workflow/build.yaml
@@ -1,0 +1,31 @@
+name: Build and Deploy image
+
+on:
+  push:
+    branches:
+    - 'main'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: code checkout
+      uses: actions/checkout@v2
+
+    - name: install the gcloud cli
+      uses: google-github-actions/setup-gcloud@v0
+      with:
+        project_id: ${{ secrets.GOOGLE_PROJECT }}
+        service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        export_default_credentials: true
+
+    - name: build and push the docker image
+      env:
+        GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+      run: |
+        gcloud auth configure-docker australia-southeast2-docker.pkg.dev
+        docker build -t australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod/nginx:latest .
+        docker push australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod/nginx:latest
+
+        australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod

--- a/front_end_project/.github/workflow/build.yaml
+++ b/front_end_project/.github/workflow/build.yaml
@@ -27,5 +27,3 @@ jobs:
         gcloud auth configure-docker australia-southeast2-docker.pkg.dev
         docker build -t australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod/nginx:latest .
         docker push australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod/nginx:latest
-
-        australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod


### PR DESCRIPTION
The aim of this PR is to create a CI/CD Pipeline

The action does the following:
- Sets up Ubuntu Runner 
- Checkout repo into the Runner
- Install GCP CLI 
- Builds and Pushes Docker image

This PR makes Repo's secret API to access the keys necessary.

![Screenshot 2023-12-15 at 12 29 24 pm](https://github.com/Chameleon-company/Chameleon-Website/assets/54379338/490d24dd-a675-422a-89d3-efdf7fabbc6b)
