### PR TITLE
BugFix - Docker build dir

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,5 +23,6 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
         run: |
           gcloud auth configure-docker australia-southeast2-docker.pkg.dev
+          cd front_end_project
           docker build -t australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod/nginx:latest .
           docker push australia-southeast2-docker.pkg.dev/$GOOGLE_PROJECT/chameleon-image-prod/nginx:latest


### PR DESCRIPTION
Updated bash script to first change dir and run command to build docker image and deploy on GCP.

In this PR. Changed dir from root to  ```cd front_end_project```